### PR TITLE
[SMS-11]-frontend-docker-file-CONFIG

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+
+RUN npm ci
+
+COPY . .
+
+RUN npm run build    
+
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+RUN npm install -g serve
+
+COPY --from=builder /app/dist ./dist
+
+EXPOSE 3000
+
+CMD ["serve", "-s", "dist", "-l", "3000"]


### PR DESCRIPTION
Multistage Dockerfile for the frontend:
- builder stage: installs dependencies with `npm ci` and builds the Vite app into `dist/`
- runner stage: installs the lightweight `serve` package and serves the contents of `dist/` on port 3000

Enables simple containerization and running of the frontend without Nginx (for now).
